### PR TITLE
Buildfix for the "xp" version of the core (Resurrection of Evil)

### DIFF
--- a/neo/Makefile.common
+++ b/neo/Makefile.common
@@ -420,7 +420,7 @@ SOURCES_DIR = \
 	
 DIRS_C  := $(foreach dir,$(SOURCES_DIR), $(wildcard $(dir)/*.c))
 
-ifeq ($(D3XP),ON)
+ifeq ($(D3XP),1)
 	SRC_GAME	:=	$(SRC_GAME_D3XP)
 else
 	SRC_GAME	:=	$(SRC_GAME_BASE)


### PR DESCRIPTION
At the moment the "boom3_xp_libretro" version of the core (for the expansion Resurrection of Evil) can't be built, this simple PR fixes the issue (/worksforme at least :p), and hopefully the core will be available again on the buildbot :)