### PR TITLE
Makefile fix to enable build for unix-* platforms

### DIFF
--- a/neo/Makefile
+++ b/neo/Makefile
@@ -66,7 +66,7 @@ ifeq ($(STATIC_LINKING), 1)
 EXT := a
 endif
 
-ifeq ($(platform), unix)
+ifneq (,$(findstring unix,$(platform)))
 	EXT ?= so
    TARGET := $(TARGET_NAME)_libretro.$(EXT)
    fpic := -fPIC


### PR DESCRIPTION
Compilation was not successful for "unix-armv7-hardfloat-neon" (one of the options in libretro-super build scripts). Made platform recognition more flexible.